### PR TITLE
Remove `getCacheKey()` to `ConnectionInterface::class`.

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -11,12 +11,12 @@ use Yiisoft\Db\Constraint\CheckConstraint;
 use Yiisoft\Db\Constraint\Constraint;
 use Yiisoft\Db\Constraint\ForeignKeyConstraint;
 use Yiisoft\Db\Constraint\IndexConstraint;
+use Yiisoft\Db\Driver\PDO\PdoAbstractSchema;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\NotSupportedException;
 use Yiisoft\Db\Expression\Expression;
 use Yiisoft\Db\Helper\ArrayHelper;
-use Yiisoft\Db\Schema\AbstractSchema;
 use Yiisoft\Db\Schema\Builder\ColumnInterface;
 use Yiisoft\Db\Schema\ColumnSchemaInterface;
 use Yiisoft\Db\Schema\TableSchemaInterface;
@@ -50,7 +50,7 @@ use function trim;
  *   }
  * >
  */
-final class Schema extends AbstractSchema
+final class Schema extends PdoAbstractSchema
 {
     public function __construct(protected ConnectionInterface $db, SchemaCache $schemaCache, string $defaultSchema)
     {
@@ -817,7 +817,7 @@ final class Schema extends AbstractSchema
      */
     protected function getCacheKey(string $name): array
     {
-        return array_merge([self::class], $this->db->getCacheKey(), [$this->getRawTableName($name)]);
+        return array_merge([self::class], $this->generateCacheKey(), [$this->getRawTableName($name)]);
     }
 
     /**
@@ -829,6 +829,6 @@ final class Schema extends AbstractSchema
      */
     protected function getCacheTag(): string
     {
-        return md5(serialize(array_merge([self::class], $this->db->getCacheKey())));
+        return md5(serialize(array_merge([self::class], $this->generateCacheKey())));
     }
 }

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Db\Oracle\Tests;
 
 use Yiisoft\Db\Command\CommandInterface;
 use Yiisoft\Db\Connection\ConnectionInterface;
+use Yiisoft\Db\Driver\PDO\ConnectionPDOInterface;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\NotSupportedException;
@@ -237,7 +238,7 @@ final class SchemaTest extends CommonSchemaTest
 
         $commandMock = $this->createMock(CommandInterface::class);
         $commandMock->method('queryAll')->willReturn([]);
-        $mockDb = $this->createMock(ConnectionInterface::class);
+        $mockDb = $this->createMock(ConnectionPDOInterface::class);
         $mockDb->method('getQuoter')->willReturn($db->getQuoter());
         $mockDb
             ->method('createCommand')
@@ -282,5 +283,16 @@ final class SchemaTest extends CommonSchemaTest
         ]);
         */
         return parent::withIndexDataProvider();
+    }
+
+    public function testNotConnectionPDO(): void
+    {
+        $db = $this->createMock(ConnectionInterface::class);
+        $schema = new Schema($db, DbHelper::getSchemaCache(), 'system');
+
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessage('Only PDO connections are supported.');
+
+        $schema->refreshTableSchema('customer');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Issue | https://github.com/yiisoft/db/pull/650
