### PR TITLE
return type of db-oracle testSerialized is corrected

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -117,7 +117,7 @@ final class ConnectionTest extends CommonConnectionTest
         $db->close();
     }
 
-    public function testSerialized()
+    public function testSerialized(): void
     {
         $connection = $this->getConnection();
         $connection->open();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  |❌
| Breaks BC?    |❌
| Fixed issues  | return type of method corrected
