### PR TITLE
Replace call of `SchemaInterface::getRawTableName()` to `QuoterInterface::getRawTableName()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   from `$table, $columns, $rows` to `$table, $rows, $columns = []` (@Tigrov)
 - Enh #260: Support `Traversable` values for `DMLQueryBuilder::batchInsert()` method with empty columns (@Tigrov)
 - Enh #255: Implement `SqlParser` and `ExpressionBuilder` driver classes (@Tigrov)
+- Chg #272: Replace call of `SchemaInterface::getRawTableName()` to `QuoterInterface::getRawTableName()` (@Tigrov)
 
 ## 1.3.0 March 21, 2024
 

--- a/src/Command.php
+++ b/src/Command.php
@@ -54,7 +54,7 @@ final class Command extends AbstractPdoCommand
                 $returnParams[$phName]['dataType'] = PDO::PARAM_INT;
             }
 
-            $returnParams[$phName]['size'] = $columnSchemas[$name]?->getSize() ?? -1;
+            $returnParams[$phName]['size'] = isset($columnSchemas[$name]) ? $columnSchemas[$name]->getSize() : -1;
 
             $returning[] = $this->db->getQuoter()->quoteColumnName($name);
         }

--- a/src/Command.php
+++ b/src/Command.php
@@ -54,7 +54,7 @@ final class Command extends AbstractPdoCommand
                 $returnParams[$phName]['dataType'] = PDO::PARAM_INT;
             }
 
-            $returnParams[$phName]['size'] = $columnSchemas[$name]->getSize() ?? -1;
+            $returnParams[$phName]['size'] = $columnSchemas[$name]?->getSize() ?? -1;
 
             $returning[] = $this->db->getQuoter()->quoteColumnName($name);
         }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -812,7 +812,7 @@ final class Schema extends AbstractPdoSchema
      */
     protected function getCacheKey(string $name): array
     {
-        return array_merge([self::class], $this->generateCacheKey(), [$this->getRawTableName($name)]);
+        return array_merge([self::class], $this->generateCacheKey(), [$this->db->getQuoter()->getRawTableName($name)]);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | yiisoft/db#767
