### PR TITLE
Remove `getCacheKey()` and `getCacheTag()` from `Schema`

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -26,9 +26,7 @@ use function array_map;
 use function array_reverse;
 use function implode;
 use function is_array;
-use function md5;
 use function preg_replace;
-use function serialize;
 use function strtolower;
 
 /**
@@ -738,29 +736,5 @@ final class Schema extends AbstractPdoSchema
         }
 
         return $views;
-    }
-
-    /**
-     * Returns the cache key for the specified table name.
-     *
-     * @param string $name The table name.
-     *
-     * @return array The cache key.
-     */
-    protected function getCacheKey(string $name): array
-    {
-        return [self::class, ...$this->generateCacheKey(), $this->db->getQuoter()->getRawTableName($name)];
-    }
-
-    /**
-     * Returns the cache tag name.
-     *
-     * This allows {@see refresh()} to invalidate all cached table schemas.
-     *
-     * @return string The cache tag name.
-     */
-    protected function getCacheTag(): string
-    {
-        return md5(serialize([self::class, ...$this->generateCacheKey()]));
     }
 }


### PR DESCRIPTION
### Related PR
- https://github.com/yiisoft/db/pull/943

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 