### PR TITLE
Rename `getLastInsertID()` method in `ConnectionInterface` to `getLastInsertId()`

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -62,7 +62,7 @@ final class Connection extends AbstractPdoConnection
      * @throws InvalidCallException
      * @throws Throwable
      */
-    public function getLastInsertID(?string $sequenceName = null): string
+    public function getLastInsertId(?string $sequenceName = null): string
     {
         if ($sequenceName === null) {
             throw new InvalidArgumentException('Oracle not support lastInsertId without sequence name.');

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -373,7 +373,7 @@ final class CommandTest extends CommonCommandTest
         $command->delete('{{order_with_null_fk}}')->execute();
         $command->insert('{{order}}', ['customer_id' => 1, 'created_at' => $time, 'total' => 42])->execute();
         $columnValueQuery = new Query($db);
-        $orderId = $db->getLastInsertID('order_SEQ');
+        $orderId = $db->getLastInsertId('order_SEQ');
         $columnValueQuery->select('created_at')->from('{{order}}')->where(['id' => $orderId]);
         $command->insert(
             '{{order_with_null_fk}}',
@@ -558,7 +558,7 @@ final class CommandTest extends CommonCommandTest
             ],
         )->execute();
 
-        $customerId = $db->getLastInsertID('customer_SEQ');
+        $customerId = $db->getLastInsertId('customer_SEQ');
 
         $customer = $command->setSql(
             <<<SQL

--- a/tests/PdoConnectionTest.php
+++ b/tests/PdoConnectionTest.php
@@ -35,7 +35,7 @@ final class PdoConnectionTest extends CommonPdoConnectionTest
         $command->insert('item', ['name' => 'Yii2 starter', 'category_id' => 1])->execute();
         $command->insert('item', ['name' => 'Yii3 starter', 'category_id' => 1])->execute();
 
-        $this->assertSame('7', $db->getLastInsertID('item_SEQ'));
+        $this->assertSame('7', $db->getLastInsertId('item_SEQ'));
 
         $db->close();
     }
@@ -57,7 +57,7 @@ final class PdoConnectionTest extends CommonPdoConnectionTest
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Oracle not support lastInsertId without sequence name.');
 
-        $db->getLastInsertID();
+        $db->getLastInsertId();
     }
 
     /**
@@ -77,8 +77,8 @@ final class PdoConnectionTest extends CommonPdoConnectionTest
         $sql = 'INSERT INTO {{profile}}([[description]]) VALUES (\'non duplicate2\')';
         $db2->createCommand($sql)->execute();
 
-        $this->assertNotEquals($db1->getLastInsertID('profile_SEQ'), $db2->getLastInsertID('profile_SEQ'));
-        $this->assertNotEquals($db2->getLastInsertID('profile_SEQ'), $db1->getLastInsertID('profile_SEQ'));
+        $this->assertNotEquals($db1->getLastInsertId('profile_SEQ'), $db2->getLastInsertId('profile_SEQ'));
+        $this->assertNotEquals($db2->getLastInsertId('profile_SEQ'), $db1->getLastInsertId('profile_SEQ'));
 
         $db1->close();
         $db2->close();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

Related to https://github.com/yiisoft/db/pull/965
