### PR TITLE
Make `TestTrait::getDriverName()` static

### DIFF
--- a/tests/Support/TestTrait.php
+++ b/tests/Support/TestTrait.php
@@ -61,7 +61,7 @@ trait TestTrait
         return $this->dsn;
     }
 
-    protected function getDriverName(): string
+    protected static function getDriverName(): string
     {
         return 'oci';
     }


### PR DESCRIPTION
### Related PR
- https://github.com/yiisoft/db/pull/988

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
