### PR TITLE
Remove test for schema-wide getter removed in yiisoft/db#1175

### DIFF
--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -80,14 +80,6 @@ final class SchemaTest extends CommonSchemaTest
         $db->close();
     }
 
-    public function testGetSchemaDefaultValues(): void
-    {
-        $this->expectException(NotSupportedException::class);
-        $this->expectExceptionMessage('Yiisoft\Db\Oracle\Schema::loadTableDefaultValues is not supported by Oracle.');
-
-        parent::testGetSchemaDefaultValues();
-    }
-
     public function testGetSchemaNames(): void
     {
         $db = $this->getSharedConnection();


### PR DESCRIPTION
Companion to yiisoft/db#1175, which removes `getSchemaDefaultValues()` from `ConstraintSchemaInterface`.

`tests/SchemaTest.php:88` delegated to `parent::testGetSchemaDefaultValues()`, so the call fails with `Call to undefined method` once that method is gone from `CommonSchemaTest`. Removing the override; `loadTableDefaultValues()` still throws `NotSupportedException` and is covered through `getTableDefaultValues()`.

Cannot merge before the core PR. I have no Oracle instance locally, so this one is only verified by isolating the affected test — please let CI confirm.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | yiisoft/db#1175
