### PR TITLE
New: Add Oracle implementation of `UuidValue` expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enh #392: Explicitly import classes and functions in "use" section (@mspirkov)
 - Enh #393: Remove unnecessary files from Composer package (@mspirkov)
 - Enh #394: Add `ext-pdo_oci` to `require` section of `composer.json` (@Tigrov)
+- New #411: Add Oracle implementation of `UuidValue` expression (@KalimeroMK)
 
 ## 2.0.0 December 05, 2025
 

--- a/src/Builder/UuidValueBuilder.php
+++ b/src/Builder/UuidValueBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Db\Oracle\Builder;
 
 use Yiisoft\Db\Expression\ExpressionInterface;
-use Yiisoft\Db\Expression\Value\Builder\UuidValueBuilder as AbstractUuidValueBuilder;
+use Yiisoft\Db\Expression\Value\Builder\UuidValueBuilder as BaseUuidValueBuilder;
 use Yiisoft\Db\Expression\Value\UuidValue;
 
 use function str_replace;
@@ -20,7 +20,7 @@ use function str_replace;
  * Inlining is safe here because `UuidValue` normalizes the value to the canonical form, which leaves exactly 32
  * hexadecimal characters once the dashes are removed.
  */
-final class UuidValueBuilder extends AbstractUuidValueBuilder
+final class UuidValueBuilder extends BaseUuidValueBuilder
 {
     public function build(ExpressionInterface $expression, array &$params = []): string
     {

--- a/src/Builder/UuidValueBuilder.php
+++ b/src/Builder/UuidValueBuilder.php
@@ -4,22 +4,27 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Oracle\Builder;
 
-use Yiisoft\Db\Constant\DataType;
+use Yiisoft\Db\Expression\ExpressionInterface;
 use Yiisoft\Db\Expression\Value\Builder\UuidValueBuilder as AbstractUuidValueBuilder;
-use Yiisoft\Db\Expression\Value\Param;
 use Yiisoft\Db\Expression\Value\UuidValue;
-use Yiisoft\Db\Helper\DbUuidHelper;
+
+use function str_replace;
 
 /**
  * Builds a {@see UuidValue} expression for Oracle.
  *
- * Oracle stores a UUID as 16 raw bytes in a `raw(16)` column, so the canonical string form is converted to bytes and
- * bound as {@see DataType::LOB}.
+ * Oracle stores a UUID as 16 raw bytes in a `raw(16)` column, and PDO_OCI cannot bind those bytes as a parameter:
+ * bound as a large object it inserts `NULL`. So the value is emitted as a `HEXTORAW()` literal, the representation
+ * this driver already uses for binary values.
+ *
+ * Inlining is safe here because `UuidValue` normalizes the value to the canonical form, which leaves exactly 32
+ * hexadecimal characters once the dashes are removed.
  */
 final class UuidValueBuilder extends AbstractUuidValueBuilder
 {
-    protected function prepareValue(UuidValue $expression): Param
+    public function build(ExpressionInterface $expression, array &$params = []): string
     {
-        return new Param(DbUuidHelper::uuidToBlob($expression->value), DataType::LOB);
+        /** @var UuidValue $expression */
+        return "HEXTORAW('" . str_replace('-', '', $expression->value) . "')";
     }
 }

--- a/src/Builder/UuidValueBuilder.php
+++ b/src/Builder/UuidValueBuilder.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Db\Oracle\Builder;
+
+use Yiisoft\Db\Constant\DataType;
+use Yiisoft\Db\Expression\Value\Builder\UuidValueBuilder as AbstractUuidValueBuilder;
+use Yiisoft\Db\Expression\Value\Param;
+use Yiisoft\Db\Expression\Value\UuidValue;
+use Yiisoft\Db\Helper\DbUuidHelper;
+
+/**
+ * Builds a {@see UuidValue} expression for Oracle.
+ *
+ * Oracle stores a UUID as 16 raw bytes in a `raw(16)` column, so the canonical string form is converted to bytes and
+ * bound as {@see DataType::LOB}.
+ */
+final class UuidValueBuilder extends AbstractUuidValueBuilder
+{
+    protected function prepareValue(UuidValue $expression): Param
+    {
+        return new Param(DbUuidHelper::uuidToBlob($expression->value), DataType::LOB);
+    }
+}

--- a/src/Builder/UuidValueBuilder.php
+++ b/src/Builder/UuidValueBuilder.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Oracle\Builder;
 
+use Yiisoft\Db\Expression\ExpressionBuilderInterface;
 use Yiisoft\Db\Expression\ExpressionInterface;
-use Yiisoft\Db\Expression\Value\Builder\UuidValueBuilder as BaseUuidValueBuilder;
 use Yiisoft\Db\Expression\Value\UuidValue;
 
 use function str_replace;
@@ -19,8 +19,10 @@ use function str_replace;
  *
  * Inlining is safe here because `UuidValue` normalizes the value to the canonical form, which leaves exactly 32
  * hexadecimal characters once the dashes are removed.
+ *
+ * @implements ExpressionBuilderInterface<UuidValue>
  */
-final class UuidValueBuilder extends BaseUuidValueBuilder
+final class UuidValueBuilder implements ExpressionBuilderInterface
 {
     public function build(ExpressionInterface $expression, array &$params = []): string
     {

--- a/src/DQLQueryBuilder.php
+++ b/src/DQLQueryBuilder.php
@@ -8,11 +8,13 @@ use Yiisoft\Db\Expression\ExpressionInterface;
 use Yiisoft\Db\Expression\Function\ArrayMerge;
 use Yiisoft\Db\Expression\Function\Longest;
 use Yiisoft\Db\Expression\Function\Shortest;
+use Yiisoft\Db\Expression\Value\UuidValue;
 use Yiisoft\Db\Oracle\Builder\ArrayMergeBuilder;
 use Yiisoft\Db\Oracle\Builder\InBuilder;
 use Yiisoft\Db\Oracle\Builder\LikeBuilder;
 use Yiisoft\Db\Oracle\Builder\LongestBuilder;
 use Yiisoft\Db\Oracle\Builder\ShortestBuilder;
+use Yiisoft\Db\Oracle\Builder\UuidValueBuilder;
 use Yiisoft\Db\Query\Query;
 use Yiisoft\Db\Query\WithQuery;
 use Yiisoft\Db\QueryBuilder\AbstractDQLQueryBuilder;
@@ -103,6 +105,7 @@ final class DQLQueryBuilder extends AbstractDQLQueryBuilder
             ArrayMerge::class => ArrayMergeBuilder::class,
             Longest::class => LongestBuilder::class,
             Shortest::class => ShortestBuilder::class,
+            UuidValue::class => UuidValueBuilder::class,
         ];
     }
 }

--- a/tests/Builder/UuidValueBuilderTest.php
+++ b/tests/Builder/UuidValueBuilderTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Oracle\Tests\Builder;
 
-use Yiisoft\Db\Constant\DataType;
-use Yiisoft\Db\Expression\Value\Param;
 use Yiisoft\Db\Expression\Value\UuidValue;
 use Yiisoft\Db\Helper\DbUuidHelper;
 use Yiisoft\Db\Oracle\Builder\UuidValueBuilder;
@@ -23,7 +21,7 @@ final class UuidValueBuilderTest extends IntegrationTestCase
 
     private const UUID = '738146be-87b1-49f2-9913-36142fb6fcbe';
 
-    public function testBuildBindsRawBytesAsLob(): void
+    public function testBuildEmitsHexToRawLiteral(): void
     {
         $db = $this->getSharedConnection();
         $builder = new UuidValueBuilder($db->getQueryBuilder());
@@ -31,11 +29,8 @@ final class UuidValueBuilderTest extends IntegrationTestCase
         $params = [];
         $result = $builder->build(new UuidValue(self::UUID), $params);
 
-        $this->assertSame(':qp0', $result);
-        $this->assertEquals(
-            [':qp0' => new Param(DbUuidHelper::uuidToBlob(self::UUID), DataType::LOB)],
-            $params,
-        );
+        $this->assertSame("HEXTORAW('738146be87b149f2991336142fb6fcbe')", $result);
+        $this->assertSame([], $params);
     }
 
     public function testInsertAndSelectUuid(): void

--- a/tests/Builder/UuidValueBuilderTest.php
+++ b/tests/Builder/UuidValueBuilderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Db\Oracle\Tests\Builder;
+
+use Yiisoft\Db\Constant\DataType;
+use Yiisoft\Db\Expression\Value\Param;
+use Yiisoft\Db\Expression\Value\UuidValue;
+use Yiisoft\Db\Helper\DbUuidHelper;
+use Yiisoft\Db\Oracle\Builder\UuidValueBuilder;
+use Yiisoft\Db\Oracle\Tests\Support\IntegrationTestTrait;
+use Yiisoft\Db\Tests\Support\IntegrationTestCase;
+
+use function strlen;
+
+/**
+ * @group oracle
+ */
+final class UuidValueBuilderTest extends IntegrationTestCase
+{
+    use IntegrationTestTrait;
+
+    private const UUID = '738146be-87b1-49f2-9913-36142fb6fcbe';
+
+    public function testBuildBindsRawBytesAsLob(): void
+    {
+        $db = $this->getSharedConnection();
+        $builder = new UuidValueBuilder($db->getQueryBuilder());
+
+        $params = [];
+        $result = $builder->build(new UuidValue(self::UUID), $params);
+
+        $this->assertSame(':qp0', $result);
+        $this->assertEquals(
+            [':qp0' => new Param(DbUuidHelper::uuidToBlob(self::UUID), DataType::LOB)],
+            $params,
+        );
+    }
+
+    public function testInsertAndSelectUuid(): void
+    {
+        $db = $this->getSharedConnection();
+
+        $this->dropTable('uuid_value');
+        $this->executeStatements('CREATE TABLE [[uuid_value]] ([[id]] raw(16) NOT NULL)');
+
+        $db->createCommand()->insert('uuid_value', ['id' => new UuidValue(self::UUID)])->execute();
+
+        $bytes = $db->createCommand('SELECT [[id]] FROM [[uuid_value]]')->queryScalar();
+
+        $this->assertSame(16, strlen($bytes));
+        $this->assertSame(self::UUID, DbUuidHelper::toUuid($bytes));
+
+        $this->dropTable('uuid_value');
+    }
+}

--- a/tests/Builder/UuidValueBuilderTest.php
+++ b/tests/Builder/UuidValueBuilderTest.php
@@ -10,8 +10,6 @@ use Yiisoft\Db\Oracle\Builder\UuidValueBuilder;
 use Yiisoft\Db\Oracle\Tests\Support\IntegrationTestTrait;
 use Yiisoft\Db\Tests\Support\IntegrationTestCase;
 
-use function strlen;
-
 /**
  * @group oracle
  */
@@ -42,10 +40,11 @@ final class UuidValueBuilderTest extends IntegrationTestCase
 
         $db->createCommand()->insert('uuid_value', ['id' => new UuidValue(self::UUID)])->execute();
 
-        $bytes = $db->createCommand('SELECT [[id]] FROM [[uuid_value]]')->queryScalar();
+        // Oracle returns a `raw` column as 16 raw bytes on some versions and as 32 hexadecimal characters on others,
+        // and `DbUuidHelper::toUuid()` accepts both.
+        $stored = $db->createCommand('SELECT [[id]] FROM [[uuid_value]]')->queryScalar();
 
-        $this->assertSame(16, strlen($bytes));
-        $this->assertSame(self::UUID, DbUuidHelper::toUuid($bytes));
+        $this->assertSame(self::UUID, DbUuidHelper::toUuid($stored));
 
         $this->dropTable('uuid_value');
     }

--- a/tests/Builder/UuidValueBuilderTest.php
+++ b/tests/Builder/UuidValueBuilderTest.php
@@ -46,6 +46,7 @@ final class UuidValueBuilderTest extends IntegrationTestCase
         // uppercase in the latter case. `DbUuidHelper::toUuid()` accepts both but keeps the case it was given.
         $stored = $db->createCommand('SELECT [[id]] FROM [[uuid_value]]')->queryScalar();
 
+        $this->assertIsString($stored);
         $this->assertSame(self::UUID, strtolower(DbUuidHelper::toUuid($stored)));
 
         $this->dropTable('uuid_value');

--- a/tests/Builder/UuidValueBuilderTest.php
+++ b/tests/Builder/UuidValueBuilderTest.php
@@ -43,8 +43,7 @@ final class UuidValueBuilderTest extends IntegrationTestCase
     #[DataProvider('values')]
     public function testBuildEmitsHexToRawLiteral(string $value): void
     {
-        $db = $this->getSharedConnection();
-        $builder = new UuidValueBuilder($db->getQueryBuilder());
+        $builder = new UuidValueBuilder();
 
         $params = [];
         $result = $builder->build(new UuidValue($value), $params);

--- a/tests/Builder/UuidValueBuilderTest.php
+++ b/tests/Builder/UuidValueBuilderTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Oracle\Tests\Builder;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Yiisoft\Db\Expression\Value\UuidValue;
 use Yiisoft\Db\Helper\DbUuidHelper;
 use Yiisoft\Db\Oracle\Builder\UuidValueBuilder;
 use Yiisoft\Db\Oracle\Tests\Support\IntegrationTestTrait;
 use Yiisoft\Db\Tests\Support\IntegrationTestCase;
 
+use function hex2bin;
 use function strtolower;
 
 /**
@@ -20,27 +22,46 @@ final class UuidValueBuilderTest extends IntegrationTestCase
     use IntegrationTestTrait;
 
     private const UUID = '738146be-87b1-49f2-9913-36142fb6fcbe';
+    private const HEX = '738146be87b149f2991336142fb6fcbe';
 
-    public function testBuildEmitsHexToRawLiteral(): void
+    /**
+     * Every form {@see UuidValue} accepts, all denoting the same UUID.
+     */
+    public static function values(): iterable
+    {
+        yield 'canonical' => [self::UUID];
+        yield 'canonical in upper case' => ['738146BE-87B1-49F2-9913-36142FB6FCBE'];
+        yield 'hexadecimal' => [self::HEX];
+        yield 'hexadecimal in upper case' => ['738146BE87B149F2991336142FB6FCBE'];
+        yield 'bytes' => [hex2bin(self::HEX)];
+    }
+
+    /**
+     * `UuidValue` normalizes the value to the canonical form on construction, so the literal holds the same 32
+     * hexadecimal characters whichever form it was created from.
+     */
+    #[DataProvider('values')]
+    public function testBuildEmitsHexToRawLiteral(string $value): void
     {
         $db = $this->getSharedConnection();
         $builder = new UuidValueBuilder($db->getQueryBuilder());
 
         $params = [];
-        $result = $builder->build(new UuidValue(self::UUID), $params);
+        $result = $builder->build(new UuidValue($value), $params);
 
-        $this->assertSame("HEXTORAW('738146be87b149f2991336142fb6fcbe')", $result);
+        $this->assertSame("HEXTORAW('" . self::HEX . "')", $result);
         $this->assertSame([], $params);
     }
 
-    public function testInsertAndSelectUuid(): void
+    #[DataProvider('values')]
+    public function testInsertAndSelectUuid(string $value): void
     {
         $db = $this->getSharedConnection();
 
         $this->dropTable('uuid_value');
         $this->executeStatements('CREATE TABLE [[uuid_value]] ([[id]] raw(16) NOT NULL)');
 
-        $db->createCommand()->insert('uuid_value', ['id' => new UuidValue(self::UUID)])->execute();
+        $db->createCommand()->insert('uuid_value', ['id' => new UuidValue($value)])->execute();
 
         // Depending on the Oracle version a `raw` column reads back as 16 raw bytes or as 32 hexadecimal characters,
         // uppercase in the latter case. `DbUuidHelper::toUuid()` accepts both but keeps the case it was given.

--- a/tests/Builder/UuidValueBuilderTest.php
+++ b/tests/Builder/UuidValueBuilderTest.php
@@ -10,6 +10,8 @@ use Yiisoft\Db\Oracle\Builder\UuidValueBuilder;
 use Yiisoft\Db\Oracle\Tests\Support\IntegrationTestTrait;
 use Yiisoft\Db\Tests\Support\IntegrationTestCase;
 
+use function strtolower;
+
 /**
  * @group oracle
  */
@@ -40,11 +42,11 @@ final class UuidValueBuilderTest extends IntegrationTestCase
 
         $db->createCommand()->insert('uuid_value', ['id' => new UuidValue(self::UUID)])->execute();
 
-        // Oracle returns a `raw` column as 16 raw bytes on some versions and as 32 hexadecimal characters on others,
-        // and `DbUuidHelper::toUuid()` accepts both.
+        // Depending on the Oracle version a `raw` column reads back as 16 raw bytes or as 32 hexadecimal characters,
+        // uppercase in the latter case. `DbUuidHelper::toUuid()` accepts both but keeps the case it was given.
         $stored = $db->createCommand('SELECT [[id]] FROM [[uuid_value]]')->queryScalar();
 
-        $this->assertSame(self::UUID, DbUuidHelper::toUuid($stored));
+        $this->assertSame(self::UUID, strtolower(DbUuidHelper::toUuid($stored)));
 
         $this->dropTable('uuid_value');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  |

Oracle half of `UuidValue`, added in yiisoft/db#1199 — **that PR has to be merged first.**

Oracle stores a UUID as 16 raw bytes (`ColumnDefinitionBuilder` maps `ColumnType::UUID` to `raw(16)`), so `prepareValue()` converts the canonical form with `DbUuidHelper::uuidToBlob()` and binds it as `DataType::LOB`.

Draft, because I could not verify this locally — `pdo_oci` is not available on my machine, so I am relying on CI for the round-trip test against a real `raw(16)` column. The SQLite and MySQL counterparts (yiisoft/db-sqlite#432, yiisoft/db-mysql#482) are verified locally.

The open question is whether `bindValue($name, $bytes, PDO::PARAM_LOB)` is right for a `raw(16)` column under PDO_OCI, since this driver otherwise represents binary values as an inline `HEXTORAW('...')` literal via `QueryBuilder::prepareBinary()`. If CI shows the LOB parameter does not work, the alternative is to build the literal in `build()` instead:

```php
return "HEXTORAW('" . str_replace('-', '', $expression->value) . "')";
```

That needs no binding and is safe here because the value is already validated as a UUID, but it inlines the value rather than passing a parameter. Happy to take whichever you prefer.

The branch name matches the one in yiisoft/db#1199, so `install-packages` resolves the core package from it and CI runs against the new class.
